### PR TITLE
Watch CSS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,8 +145,10 @@ gulp.task('watch', function () {
   gulp.start('server');
   gulp.watch([
     paths.src + '**/*.js',
+    paths.root + '**/*.css',
+    paths.root + '**/*.html',
     '!' + paths.src + 'third-party/**',
-    paths.test + '**/*.js',
+    '!' + paths.test + '**/*.js'
   ], ['quick']);
 });
 


### PR DESCRIPTION
Updated the `gulp watch` command to watch CSS and HTML files inside of the app folder so that CSS files are automatically browserified and it will live-reload the page with the new changes.